### PR TITLE
RPi.GPIO Version

### DIFF
--- a/custom_components/dht/manifest.json
+++ b/custom_components/dht/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/richardzone/homeassistant-dht/issues",
   "requirements": [
     "adafruit-circuitpython-dht==3.7.0",
-    "RPi.GPIO==0.7.1a4",
+    "RPi.GPIO==0.7.1",
     "tenacity==8.0.1"
   ],
   "codeowners": [


### PR DESCRIPTION
It works correctly and does not need to be compiled during installation.